### PR TITLE
Implement WireMock connectivity and ping endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     *   **Web (Nuxt):** [http://localhost:3000](http://localhost:3000)
     *   **API (Spring Boot):** [http://localhost:8080/health](http://localhost:8080/health) -> Should return `OK`
     *   **WireMock:** [http://localhost:8082/mock/ping](http://localhost:8082/mock/ping) -> Should return `{ "ok": true }`
+    *   **API -> WireMock:** [http://localhost:8080/wiremock/ping](http://localhost:8080/wiremock/ping) -> Should return `{ "ok": true }`
 
 ### DB Migration (Flyway)
 

--- a/api/src/main/kotlin/com/example/demo/WireMockController.kt
+++ b/api/src/main/kotlin/com/example/demo/WireMockController.kt
@@ -1,0 +1,23 @@
+package com.example.demo
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.client.RestClient
+
+@RestController
+class WireMockController(
+    restClientBuilder: RestClient.Builder,
+    @Value("\${app.wiremock.base-url}") wireMockBaseUrl: String
+) {
+
+    private val restClient = restClientBuilder.baseUrl(wireMockBaseUrl).build()
+
+    @GetMapping("/wiremock/ping")
+    fun ping(): Map<*, *>? {
+        return restClient.get()
+            .uri("/mock/ping")
+            .retrieve()
+            .body(Map::class.java)
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -14,6 +14,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+app:
+  wiremock:
+    base-url: ${WIREMOCK_BASE_URL:http://wiremock:8080}
+
 management:
   endpoints:
     web:

--- a/api/src/test/kotlin/com/example/demo/WireMockControllerTest.kt
+++ b/api/src/test/kotlin/com/example/demo/WireMockControllerTest.kt
@@ -1,0 +1,34 @@
+package com.example.demo
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+
+@RestClientTest(WireMockController::class, properties = ["app.wiremock.base-url=http://test-wiremock"])
+class WireMockControllerTest {
+
+    @Autowired
+    private lateinit var server: MockRestServiceServer
+
+    @Autowired
+    private lateinit var controller: WireMockController
+
+    @Test
+    fun `ping should call wiremock and return response`() {
+        // Arrange
+        val expectedJson = """{"ok": true}"""
+        server.expect(requestTo("http://test-wiremock/mock/ping"))
+            .andRespond(withSuccess(expectedJson, MediaType.APPLICATION_JSON))
+
+        // Act
+        val result = controller.ping()
+
+        // Assert
+        assertEquals(mapOf("ok" to true), result)
+    }
+}


### PR DESCRIPTION
Addresses Issue #3 by enabling connectivity between the Spring Boot API and WireMock.
- Configures `RestClient` to talk to WireMock.
- Exposes `/wiremock/ping` which proxies to WireMock's `/mock/ping`.
- Includes unit tests.

---
*PR created automatically by Jules for task [2220662869795904427](https://jules.google.com/task/2220662869795904427) started by @ht-0328*