### PR TITLE
web を Nuxt 4 で初期化し起動設定を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@
     *   **WireMock:** [http://localhost:8082/mock/ping](http://localhost:8082/mock/ping) -> `{ "ok": true }` が返るはずです
     *   **API -> WireMock:** [http://localhost:8080/wiremock/ping](http://localhost:8080/wiremock/ping) -> `{ "ok": true }` が返るはずです
 
+### Web (Nuxt) 開発
+
+Web アプリケーションを手動でセットアップ・起動する場合の手順:
+
+1.  Dev Container に入ります。
+2.  依存関係をインストールします:
+    ```bash
+    cd web && npm install
+    ```
+3.  開発サーバーを起動します:
+    ```bash
+    npm run dev
+    ```
+4.  ブラウザで確認します:
+    [http://localhost:3000](http://localhost:3000)
+
 ### DB マイグレーション (Flyway)
 
 マイグレーションは起動時（`dev-up.sh` 経由）に自動的に適用されます。

--- a/web/README.md
+++ b/web/README.md
@@ -1,10 +1,10 @@
 # Nuxt Minimal Starter
 
-詳細については、[Nuxt ドキュメント](https://nuxt.com/docs/getting-started/introduction) を参照してください。
+Look at the [Nuxt documentation](https://nuxt.com/docs/getting-started/introduction) to learn more.
 
-## セットアップ
+## Setup
 
-依存関係をインストールしてください:
+Make sure to install dependencies:
 
 ```bash
 # npm
@@ -20,9 +20,9 @@ yarn install
 bun install
 ```
 
-## 開発サーバー
+## Development Server
 
-`http://localhost:3000` で開発サーバーを起動します:
+Start the development server on `http://localhost:3000`:
 
 ```bash
 # npm
@@ -38,9 +38,9 @@ yarn dev
 bun run dev
 ```
 
-## 本番環境
+## Production
 
-本番環境用にアプリケーションをビルドします:
+Build the application for production:
 
 ```bash
 # npm
@@ -56,7 +56,7 @@ yarn build
 bun run build
 ```
 
-本番ビルドをローカルでプレビューします:
+Locally preview production build:
 
 ```bash
 # npm
@@ -72,4 +72,4 @@ yarn preview
 bun run preview
 ```
 
-詳細については、[デプロイメントドキュメント](https://nuxt.com/docs/getting-started/deployment) を確認してください。
+Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,9 +7,9 @@
       "name": "web",
       "hasInstallScript": true,
       "dependencies": {
-        "nuxt": "^3.15.4",
-        "vue": "^3.5.13",
-        "vue-router": "^4.5.0"
+        "nuxt": "^4.3.0",
+        "vue": "^3.5.27",
+        "vue-router": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -475,37 +475,6 @@
         "chokidar": "^5.0.0",
         "pathe": "^2.0.3",
         "tinyglobby": "^0.2.15"
-      }
-    },
-    "node_modules/@dxup/nuxt/node_modules/@nuxt/kit": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.0.tgz",
-      "integrity": "sha512-cD/0UU9RQmlnTbmyJTDyzN8f6CzpziDLv3tFQCnwl0Aoxt3KmFu4k/XA4Sogxqj7jJ/3cdX1kL+Lnsh34sxcQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.3.3",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
-        "jiti": "^2.6.1",
-        "klona": "^2.0.6",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
-        "scule": "^1.3.0",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unctx": "^2.5.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
       }
     },
     "node_modules/@dxup/unimport": {
@@ -1353,37 +1322,6 @@
         "vite": ">=6.0"
       }
     },
-    "node_modules/@nuxt/devtools-kit/node_modules/@nuxt/kit": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.0.tgz",
-      "integrity": "sha512-cD/0UU9RQmlnTbmyJTDyzN8f6CzpziDLv3tFQCnwl0Aoxt3KmFu4k/XA4Sogxqj7jJ/3cdX1kL+Lnsh34sxcQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.3.3",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
-        "jiti": "^2.6.1",
-        "klona": "^2.0.6",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
-        "scule": "^1.3.0",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unctx": "^2.5.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
     "node_modules/@nuxt/devtools-wizard": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@nuxt/devtools-wizard/-/devtools-wizard-3.1.1.tgz",
@@ -1403,7 +1341,7 @@
         "devtools-wizard": "cli.mjs"
       }
     },
-    "node_modules/@nuxt/devtools/node_modules/@nuxt/kit": {
+    "node_modules/@nuxt/kit": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.3.0.tgz",
       "integrity": "sha512-cD/0UU9RQmlnTbmyJTDyzN8f6CzpziDLv3tFQCnwl0Aoxt3KmFu4k/XA4Sogxqj7jJ/3cdX1kL+Lnsh34sxcQQ==",
@@ -1434,46 +1372,14 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/kit": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
-      "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.3.3",
-        "consola": "^3.4.2",
-        "defu": "^6.1.4",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
-        "jiti": "^2.6.1",
-        "klona": "^2.0.6",
-        "knitwork": "^1.3.0",
-        "mlly": "^1.8.0",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2",
-        "scule": "^1.3.0",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unctx": "^2.5.0",
-        "untyped": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
     "node_modules/@nuxt/nitro-server": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-3.21.0.tgz",
-      "integrity": "sha512-lM+PPyJf6NpWC7EqcttnNgkh1aGFlb2q1YnyHX/C9OSvF2XUXbSkNKhVclZtYSyZ6aUQSek9P1MRKcaEh7bgpw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.3.0.tgz",
+      "integrity": "sha512-NkI8q8211BTLfQr6m24PjBp9GGyKWJMxRGSqe5WGgpQD5BpSnlvM8l1HaaP4xn9/P4v1Hp/LxX+vYElY2fw/zw==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/kit": "3.21.0",
+        "@nuxt/kit": "4.3.0",
         "@unhead/vue": "^2.1.2",
         "@vue/shared": "^3.5.27",
         "consola": "^3.4.2",
@@ -1504,13 +1410,13 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "nuxt": "^3.21.0"
+        "nuxt": "^4.3.0"
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.21.0.tgz",
-      "integrity": "sha512-s4cDCQrlG3RbUXowTDlQVR/tsWW2Wd2PQ0Pw/QV5x2Mzp26VH0XyGZ3zYkaDPt23BsjrbF/XA4Bhut5YREfxbg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.3.0.tgz",
+      "integrity": "sha512-+Ps3exseMFH3MOapbBmDdpaHpPV7wqcB6+Ir9w8h91771HwMOWrQomAZpqDvw7FtFraoD5Xw7dhSKDhkwJRSmQ==",
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "^3.5.27",
@@ -1549,13 +1455,45 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/vite-builder": {
+    "node_modules/@nuxt/telemetry/node_modules/@nuxt/kit": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.21.0.tgz",
-      "integrity": "sha512-XxwadSMlpvtjDstTtUHdXhLAGldZlWNmPhfAGo5PhsrXhidrjHcODXTGnh9iC1mbVu8xML78/m2rhB9MFHSCyw==",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
+      "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "3.21.0",
+        "c12": "^3.3.3",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "errx": "^0.1.0",
+        "exsolve": "^1.0.8",
+        "ignore": "^7.0.5",
+        "jiti": "^2.6.1",
+        "klona": "^2.0.6",
+        "knitwork": "^1.3.0",
+        "mlly": "^1.8.0",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "rc9": "^2.1.2",
+        "scule": "^1.3.0",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ufo": "^1.6.3",
+        "unctx": "^2.5.0",
+        "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@nuxt/vite-builder": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.3.0.tgz",
+      "integrity": "sha512-qOVevlukWUztfJ9p/OtujRxwaXIsnoTo2ZW4pPY1zQcuR1DtBtBsiePLzftoDz1VGx9JF5GAx9YyrgTn/EmcWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "4.3.0",
         "@rollup/plugin-replace": "^6.0.3",
         "@vitejs/plugin-vue": "^6.0.3",
         "@vitejs/plugin-vue-jsx": "^5.1.3",
@@ -1566,16 +1504,13 @@
         "esbuild": "^0.27.2",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.0.8",
-        "externality": "^1.0.2",
         "get-port-please": "^3.2.0",
         "jiti": "^2.6.1",
         "knitwork": "^1.3.0",
         "magic-string": "^0.30.21",
         "mlly": "^1.8.0",
         "mocked-exports": "^0.1.1",
-        "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
         "pkg-types": "^2.3.0",
         "postcss": "^8.5.6",
         "rollup-plugin-visualizer": "^6.0.5",
@@ -1592,7 +1527,7 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "nuxt": "3.21.0",
+        "nuxt": "4.3.0",
         "rolldown": "^1.0.0-beta.38",
         "vue": "^3.3.4"
       },
@@ -4418,9 +4353,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001767",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
-      "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
+      "version": "1.0.30001768",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001768.tgz",
+      "integrity": "sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4533,6 +4468,15 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -5172,19 +5116,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -5355,24 +5286,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "license": "MIT"
-    },
-    "node_modules/externality": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/externality/-/externality-1.0.2.tgz",
-      "integrity": "sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==",
-      "license": "MIT",
-      "dependencies": {
-        "enhanced-resolve": "^5.14.1",
-        "mlly": "^1.3.0",
-        "pathe": "^1.1.1",
-        "ufo": "^1.1.2"
-      }
-    },
-    "node_modules/externality/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -6375,13 +6288,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -6842,19 +6755,19 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.21.0.tgz",
-      "integrity": "sha512-K3vX68M0lXbqzvehWb+y6/YqAF+m7MEQQ3mtbcm34ynzB6OpFOJoZV9scBzFd5LehLoYl55CSNpY5vsupyJw7Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.3.0.tgz",
+      "integrity": "sha512-99Iw3E3L5/2QtJyV4errZ0axkX/S9IAFK0AHm0pmRHkCu37OFn8mz2P4/CYTt6B/TG3mcKbXAVaeuF2FsAc1cA==",
       "license": "MIT",
       "dependencies": {
         "@dxup/nuxt": "^0.3.2",
         "@nuxt/cli": "^3.32.0",
         "@nuxt/devtools": "^3.1.1",
-        "@nuxt/kit": "3.21.0",
-        "@nuxt/nitro-server": "3.21.0",
-        "@nuxt/schema": "3.21.0",
+        "@nuxt/kit": "4.3.0",
+        "@nuxt/nitro-server": "4.3.0",
+        "@nuxt/schema": "4.3.0",
         "@nuxt/telemetry": "^2.6.6",
-        "@nuxt/vite-builder": "3.21.0",
+        "@nuxt/vite-builder": "4.3.0",
         "@unhead/vue": "^2.1.2",
         "@vue/shared": "^3.5.27",
         "c12": "^3.3.3",
@@ -6914,7 +6827,7 @@
       },
       "peerDependencies": {
         "@parcel/watcher": "^2.1.0",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "@types/node": ">=18.12.0"
       },
       "peerDependenciesMeta": {
         "@parcel/watcher": {
@@ -6926,9 +6839,9 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.4.tgz",
-      "integrity": "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.0",
@@ -8188,9 +8101,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8641,15 +8554,6 @@
         "url": "https://opencollective.com/svgo"
       }
     },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/system-architecture": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
@@ -8672,19 +8576,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {

--- a/web/package.json
+++ b/web/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev",
+    "dev": "nuxt dev --host 0.0.0.0 --port 3000",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "nuxt": "^3.15.4",
-    "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "nuxt": "^4.3.0",
+    "vue": "^3.5.27",
+    "vue-router": "^4.6.4"
   }
 }


### PR DESCRIPTION
issue #7 に基づき、`web` ディレクトリを Nuxt 4 で再作成しました。

変更点:
*   `web/` ディレクトリを Nuxt 4 (minimal template) で初期化。
*   `web/package.json` の `dev` スクリプトを `nuxt dev --host 0.0.0.0 --port 3000` に変更し、DevContainer からホストへのポートフォワーディングに対応。
*   `README.md` に Web アプリケーションのセットアップと起動手順を追記。

検証:
*   DevContainer 内で `npm run dev` を実行し、ホスト側の `http://localhost:3000` で Nuxt 4 のウェルカムページが表示されることを確認しました。

---
*PR created automatically by Jules for task [10392972196286676500](https://jules.google.com/task/10392972196286676500) started by @ht-0328*