### PR TITLE
NuxtからAPIへの疎通確認ページを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 6.  サービスを確認します:
     *   **Web (Nuxt):** [http://localhost:3000](http://localhost:3000)
     *   **API (Spring Boot):** [http://localhost:8080/health](http://localhost:8080/health) -> `OK` が返るはずです
+    *   **Web -> API (疎通確認):** [http://localhost:3000/health](http://localhost:3000/health) -> `Result: OK` が表示されるはずです
     *   **WireMock:** [http://localhost:8082/mock/ping](http://localhost:8082/mock/ping) -> `{ "ok": true }` が返るはずです
     *   **API -> WireMock:** [http://localhost:8080/wiremock/ping](http://localhost:8080/wiremock/ping) -> `{ "ok": true }` が返るはずです
 

--- a/api/src/main/kotlin/com/example/demo/CorsConfig.kt
+++ b/api/src/main/kotlin/com/example/demo/CorsConfig.kt
@@ -1,0 +1,19 @@
+package com.example.demo
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+/**
+ * フロントエンド（Nuxt）からのアクセスを許可するためのCORS設定。
+ * 開発環境でポートが異なるため必要。
+ */
+@Configuration
+class CorsConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+    }
+}

--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtPage />
   </div>
 </template>

--- a/web/app/pages/health.vue
+++ b/web/app/pages/health.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const config = useRuntimeConfig()
+const { data, status, error } = await useFetch(`${config.public.apiBaseUrl}/health`)
+</script>
+
+<template>
+  <div>
+    <h1>Health Check</h1>
+    <div v-if="status === 'pending'">Loading...</div>
+    <div v-else-if="status === 'error'">
+      Error: {{ error }}
+    </div>
+    <div v-else>
+      Result: {{ data }}
+    </div>
+  </div>
+</template>

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -1,5 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  runtimeConfig: {
+    public: {
+      apiBaseUrl: 'http://localhost:8080'
+    }
+  }
 })

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4469,15 +4469,6 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -8552,6 +8543,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/system-architecture": {


### PR DESCRIPTION
NuxtフロントエンドからSpring Bootバックエンドへの疎通を確認するための `/health` ページを追加しました。

変更点:
*   **Web**: `/health` ページを作成し、APIの `/health` エンドポイントを呼び出すようにしました。
*   **Web**: `app.vue` を更新し、ファイルベースルーティング (`<NuxtPage />`) を有効にしました。
*   **Web**: `runtimeConfig` を設定し、APIのベースURLを環境変数 (`NUXT_PUBLIC_API_BASE_URL`) で上書き可能にしました。
*   **API**: `CorsConfig.kt` を作成し、`localhost:3000` からのCORSリクエストを許可しました。
*   **Docs**: `README.md` に疎通確認の手順を追加しました。

理由:
フロントエンドとバックエンドの連携確認を容易にするため。Issue #10 の対応。

---
*PR created automatically by Jules for task [15859779744651400819](https://jules.google.com/task/15859779744651400819) started by @ht-0328*