### PR TITLE
feat: NuxtとAPIの疎通確認画面を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 6.  サービスを確認します:
     *   **Web (Nuxt):** [http://localhost:3000](http://localhost:3000)
+    *   **Web -> API 疎通確認:** [http://localhost:3000/health](http://localhost:3000/health) -> `OK` が表示されるはずです
     *   **API (Spring Boot):** [http://localhost:8080/health](http://localhost:8080/health) -> `OK` が返るはずです
     *   **WireMock:** [http://localhost:8082/mock/ping](http://localhost:8082/mock/ping) -> `{ "ok": true }` が返るはずです
     *   **API -> WireMock:** [http://localhost:8080/wiremock/ping](http://localhost:8080/wiremock/ping) -> `{ "ok": true }` が返るはずです

--- a/api/src/main/kotlin/com/example/demo/HealthController.kt
+++ b/api/src/main/kotlin/com/example/demo/HealthController.kt
@@ -1,9 +1,11 @@
 package com.example.demo
 
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@CrossOrigin
 class HealthController {
 
     @GetMapping("/health")

--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
     <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtPage />
   </div>
 </template>

--- a/web/app/pages/health.vue
+++ b/web/app/pages/health.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const config = useRuntimeConfig()
+const { data, status, error } = await useFetch('/health', {
+  baseURL: config.public.apiBaseUrl,
+  server: false
+})
+</script>
+
+<template>
+  <div>
+    <h1>Health Check</h1>
+    <div v-if="status === 'pending'">Loading...</div>
+    <div v-else-if="status === 'error'">
+      Error: {{ error }}
+    </div>
+    <div v-else>
+      Result: {{ data }}
+    </div>
+  </div>
+</template>

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtWelcome />
+</template>

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -1,5 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  runtimeConfig: {
+    public: {
+      apiBaseUrl: process.env.NUXT_PUBLIC_API_BASE_URL || 'http://localhost:8080'
+    }
+  }
 })

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4469,15 +4469,6 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -8552,6 +8543,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/system-architecture": {


### PR DESCRIPTION
Nuxt（frontend）からSpring Boot（backend）の /health エンドポイントへの疎通確認を行うページ /health を追加しました。
また、開発環境でブラウザからアクセス可能にするため、HealthControllerに @CrossOrigin を追加しました。
READMEに確認手順を追記しました。

---
*PR created automatically by Jules for task [11370858364062387833](https://jules.google.com/task/11370858364062387833) started by @ht-0328*