### PR TITLE
Dev Container起動時に.envを自動作成するように修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
       ]
     }
   },
+  "initializeCommand": "sh -c 'if [ ! -f .env ]; then cp .env.example .env; fi' || cmd /c \"if not exist .env copy .env.example .env\"",
   "postCreateCommand": "bash scripts/install-kotlin-lsp.sh",
   "remoteUser": "vscode"
 }


### PR DESCRIPTION
`devcontainer.json` に `initializeCommand` を追加し、OSに関わらず `.env.example` から `.env` をコピーする処理を実装しました。
これにより、開発者が手動で `.env` を作成しなくても Dev Container を起動できるようになります。
Windows (CMD) と Linux/Unix (sh) の両方に対応したコマンド記述を採用しています。

---
*PR created automatically by Jules for task [14521411623104115252](https://jules.google.com/task/14521411623104115252) started by @ht-0328*