### PR TITLE
[API] パッケージ構成をモジュラーモノリスへ変更し、AGENTS.mdに規約を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@
 - Kotlin + Spring Boot を前提にする
 - 生成コードは必ず null safety を考慮する
 - 既存の設計を壊さないことを最優先する
+- API実装はモジュラーモノリス構成を必須とする
+    - 機能（モジュール）ごとにパッケージを分割する（例: `news`, `score`）
+    - 各モジュール配下に `controller` / `service` / `repository` / `dto` / `entity` / `client` を配置する
 
 ## コーディングルール
 - data class を優先して使う

--- a/api/src/main/kotlin/com/example/demo/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/example/demo/config/SecurityConfig.kt
@@ -1,4 +1,4 @@
-package com.example.demo
+package com.example.demo.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/api/src/main/kotlin/com/example/demo/health/controller/HealthController.kt
+++ b/api/src/main/kotlin/com/example/demo/health/controller/HealthController.kt
@@ -1,4 +1,4 @@
-package com.example.demo
+package com.example.demo.health.controller
 
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController

--- a/api/src/main/kotlin/com/example/demo/wiremock/controller/WireMockController.kt
+++ b/api/src/main/kotlin/com/example/demo/wiremock/controller/WireMockController.kt
@@ -1,4 +1,4 @@
-package com.example.demo
+package com.example.demo.wiremock.controller
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping

--- a/api/src/test/kotlin/com/example/demo/wiremock/controller/WireMockControllerTest.kt
+++ b/api/src/test/kotlin/com/example/demo/wiremock/controller/WireMockControllerTest.kt
@@ -1,4 +1,4 @@
-package com.example.demo
+package com.example.demo.wiremock.controller
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
Github Issue #19 に基づき、APIのパッケージ構成をモジュラーモノリス構成へリファクタリングしました。

変更点:
- `api/src/main/kotlin/com/example/demo/` 配下のクラスを機能別モジュール (`health`, `wiremock`, `config`) に分割・移動しました。
  - `HealthController.kt` -> `health/controller/`
  - `WireMockController.kt` -> `wiremock/controller/`
  - `SecurityConfig.kt` -> `config/`
- テストクラス `WireMockControllerTest.kt` も同様に `wiremock/controller/` へ移動しました。
- `AGENTS.md` に「API実装はモジュラーモノリス構成を必須とする」旨の規約を追記しました。

検証:
- `./gradlew clean build` でコンパイル・テスト通過を確認済み。
- `/health` エンドポイントが正常に動作することを確認済み。

---
*PR created automatically by Jules for task [300856626626477382](https://jules.google.com/task/300856626626477382) started by @ht-0328*